### PR TITLE
add version string to package requests

### DIFF
--- a/kernel.js
+++ b/kernel.js
@@ -266,7 +266,24 @@
     return xmlhttp;
   }
 
+  let randomVersionString;
+  const getRandomVersionString = () => {
+    if (randomVersionString) return randomVersionString;
+
+    let win = window;
+    while (win !== window.top) {
+      win = win.parent;
+      if (win.clientVars) {
+        randomVersionString = win.clientVars.randomVersionString;
+        return randomVersionString;
+      }
+    }
+  };
+
   function getXHR(uri, async, callback, request) {
+    if (getRandomVersionString()) {
+      uri = uri + `&v=${getRandomVersionString()}`;
+    }
     var request = request || createXMLHTTPObject();
     if (!request) {
       throw new Error("Error making remote request.")


### PR DESCRIPTION
although we're going to abandon this package soon, this should be fixed imo. require cause GET requests but without a version string. This results in multiple downloads in case we download a package also via script tags, which we do, because we need some packages inside inner/outer/parent. Before this change we needed to pay special attention to the order in which we write script tags/require, but now it does not matter anymore.