### PR TITLE
update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "http://oofn.net"
   },
   "dependencies": {},
-  "version": "1.0.9",
+  "version": "1.0.10",
   "repository": {
     "type": "git",
     "url": "git://github.com/ether/etherpad-require-kernel"


### PR DESCRIPTION
If https://github.com/ether/etherpad-require-kernel/pull/3 is in, we also need a npm publish