### PR TITLE
Versionstring for parent require

### DIFF
--- a/kernel.js
+++ b/kernel.js
@@ -268,9 +268,13 @@
 
   let randomVersionString;
   const getRandomVersionString = () => {
+    let win = window;
+
+    // check the current window first, relevant for parent/pad.html requires
+    if (win.clientVars && win.clientVars.randomVersionString)
+      randomVersionString = win.clientVars.randomVersionString;
     if (randomVersionString) return randomVersionString;
 
-    let win = window;
     while (win !== window.top) {
       win = win.parent;
       if (win.clientVars) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "http://oofn.net"
   },
   "dependencies": {},
-  "version": "1.0.10",
+  "version": "1.0.11",
   "repository": {
     "type": "git",
     "url": "git://github.com/ether/etherpad-require-kernel"


### PR DESCRIPTION
missed the case of parent require in the last PR, because the loop that tries to detect `clientVars` never starts when `window === window.top`. So now look in the current window scope first.

needs npm publish after merge