### PR TITLE
Merge upstream v1.0.6 commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The kernel has the following methods:
 * `setRootURI`: The URI that non-library paths will be requested relative to. Default is `undefined`.
 * `setLibraryURI`: The URI that library paths (i.e. paths that do not match `/^\.{0,2}\//`) will be requested relative to. Default is `undefined`.
 * `setRequestMaximum`: The maximum number of concurrent requests. Default is `2`.
+* `setLibraryLookupComponent`: A string (such as `"node_modules"`). If defined, libraries will be searched for in parent directories. Default is `undefined`.
 
 ## Behavior ##
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	, "url": "http://oofn.net"
   }
 , "dependencies": {}
-, "version": "1.0.5"
+, "version": "1.0.6"
 , "repository": {
     "type": "git"
 	, "url": "git://github.com/cweider/require-kernel"

--- a/test/test.js
+++ b/test/test.js
@@ -109,7 +109,7 @@ describe('require', function () {
   });
 
   it("should detect cycles", function () {
-    r = requireForPaths('/dev/null', '/dev/null');
+    var r = requireForPaths('/dev/null', '/dev/null');
     r.define({
       "one_cycle.js": function (require, exports, module) {
         exports.value = module.id;
@@ -151,7 +151,7 @@ describe('require', function () {
   });
 
   it("should avoid avoidable cycles", function () {
-    r = requireForPaths();
+    var r = requireForPaths();
     r.define({
       "non_cycle.js": function (require, exports, module) {
         exports.value = module.id;

--- a/test/test.js
+++ b/test/test.js
@@ -108,6 +108,37 @@ describe('require', function () {
     assert.throws(function () {r('1', '1', '1')}, 'ArgumentError');
   });
 
+  it("should lookup nested libraries", function () {
+    var r = requireForPaths('/dev/null', '/dev/null');
+    r.setLibraryLookupComponent('node_modules');
+    r.define({
+      "thing0/index.js": function (require, exports, module) {
+        exports.value = module.id;
+      }
+    , "thing1/index.js": function (require, exports, module) {
+        exports.value = module.id;
+      }
+    , "/node_modules/thing1/index.js": function (require, exports, module) {
+        exports.value = module.id;
+      }
+    , "/node_modules/thing/node_modules/thing2/index.js": function (require, exports, module) {
+        exports.value = module.id;
+      }
+    , "/node_modules/thing/dir/node_modules/thing3/index.js": function (require, exports, module) {
+        exports.value = module.id;
+      }
+
+    , "/node_modules/thing/dir/load_things.js": function (require, exports, module) {
+        assert.equal(require('thing3').value, '/node_modules/thing/dir/node_modules/thing3/index.js');
+        assert.equal(require('thing2').value, '/node_modules/thing/node_modules/thing2/index.js');
+        assert.equal(require('thing1').value, '/node_modules/thing1/index.js');
+        assert.equal(require('thing0').value, 'thing0/index.js');
+      }
+    });
+
+    r('/node_modules/thing/dir/load_things.js');
+  });
+
   it("should detect cycles", function () {
     var r = requireForPaths('/dev/null', '/dev/null');
     r.define({

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,7 @@
 
 */
 
+var assert = require('assert');
 var fs = require('fs');
 var util = require('util');
 var pathutil = require('path');
@@ -14,161 +15,161 @@ var requireForPaths = require('../mock_require').requireForPaths;
 
 var modulesPath = pathutil.join(__dirname, 'modules');
 
-function assertEqual(expected, actual, reason) {
-  if (expected == actual) {
-    console.log('.');
-  } else {
-    console.log('F');
-    console.log(expected + ' != '  + actual);
-    reason && console.log(reason);
-    throw new Error()
-  }
-}
-function assertThrow(f, match) {
-  var error = undefined;
-  try {
-    f();
-  } catch (e) {
-    error = e;
-  } finally {
-    assertEqual(true, !!error);
-    if (match) {
-      assertEqual(true, !!error.toString().match(match),
-      match.toString() + " should match " + JSON.stringify(error.toString()));
-    }
-  }
-}
+describe("require.define", function () {
+  it("should work", function () {
+    var r = requireForPaths('/dev/null', '/dev/null');
+    r.define("user/module.js", function (require, exports, module) {
+      exports.value = module.id;
+    });
+    r.define("user/module.js", function (require, exports, module) {
+      exports.value = "REDEFINED";
+    });
+    r.define({
+      "user/module1.js": function (require, exports, module) {
+        exports.value = module.id;
+      }
+    , "user/module2.js": function (require, exports, module) {
+        exports.value = module.id;
+      }
+    , "user/module3.js": function (require, exports, module) {
+        exports.value = module.id;
+      }
+    });
 
-/* Test library resolution. */
-r = requireForPaths(modulesPath + '/root', modulesPath + '/library');
-assertEqual('1.js', r('1.js').value);
-assertEqual('/1.js', r('/1.js').value);
-/* Test suffix resolution. */
-assertEqual('/1.js', r('/1').value);
-assertEqual(r('/1.js'), r('/1'));
+    assert.equal('user/module.js', r('user/module').value);
+    assert.equal('user/module1.js', r('user/module1').value);
+    assert.equal('user/module2.js', r('user/module2').value);
+    assert.equal('user/module3.js', r('user/module3').value);
+  });
 
-/* Test encoding. */
-r = requireForPaths(modulesPath + '/root', modulesPath + '/library');
-assertEqual('/spa ce s.js', r('/spa ce s.js').value);
-
-/* Test questionable 'extra' relative paths. */
-r = requireForPaths(modulesPath + '/root', modulesPath + '/library');
-assertEqual('/../root/1.js', r('/../root/1').value);
-assertEqual('/../library/1.js', r('../library/1').value);
-
-/* Test relative paths in library modules */
-r = requireForPaths('/dev/null', '/dev/null');
-r.define("main.js", function (require, exports, module) {
-  exports.sibling = require('./sibling');
-});
-r.define("sibling.js", function (require, exports, module) {
-});
-assertEqual(r('main.js').sibling, r('sibling.js'));
-
-/* Test index resolution. */
-r = requireForPaths(modulesPath + '/index');
-assertEqual('/index.js', r('/').value);
-assertEqual('/index.js', r('/index').value);
-assertEqual('/index/index.js', r('/index/').value);
-assertEqual('/index/index.js', r('/index/index').value);
-assertEqual('/index/index.js', r('/index/index.js').value);
-assertEqual('/index/index/index.js', r('/index/index/').value);
-assertEqual('/index/index/index.js', r('/index/index/index.js').value);
-
-/* Test path normalization. */
-assertEqual('/index.js', r('./index').value);
-assertEqual('/index.js', r('/./index').value);
-assertEqual('/index/index.js', r('/index/index/../').value);
-assertEqual('/index/index.js', r('/index/index/../../index/').value);
-
-/* Test exceptions. */
-assertThrow(function () {r(null)}, "toString");
-assertThrow(function () {r('1', '1')}, "ArgumentError");
-assertThrow(function () {r('1', '1', '1')}, "ArgumentError");
-
-/* Test module definitions. */
-r = requireForPaths('/dev/null', '/dev/null');
-r.define("user/module.js", function (require, exports, module) {
-  exports.value = module.id;
-});
-r.define("user/module.js", function (require, exports, module) {
-  exports.value = "REDEFINED";
-});
-r.define({
-  "user/module1.js": function (require, exports, module) {
-    exports.value = module.id;
-  }
-, "user/module2.js": function (require, exports, module) {
-    exports.value = module.id;
-  }
-, "user/module3.js": function (require, exports, module) {
-    exports.value = module.id;
-  }
-});
-assertThrow(function () {r.define()}, "ArgumentError");
-assertThrow(function () {r.define(null, null)}, "ArgumentError");
-
-assertEqual('user/module.js', r('user/module').value);
-assertEqual('user/module1.js', r('user/module1').value);
-assertEqual('user/module2.js', r('user/module2').value);
-assertEqual('user/module3.js', r('user/module3').value);
-
-/* Test cycle detection */
-r = requireForPaths('/dev/null', '/dev/null');
-r.define({
-  "one_cycle.js": function (require, exports, module) {
-    exports.value = module.id;
-    exports.one = require('one_cycle');
-  }
-
-, "two_cycle.js": function (require, exports, module) {
-    exports.two = require('two_cycle.1');
-  }
-, "two_cycle.1.js": function (require, exports, module) {
-    exports.value = module.id;
-    exports.two = require('two_cycle.2');
-  }
-, "two_cycle.2.js": function (require, exports, module) {
-    exports.value = module.id;
-    exports.one = require('two_cycle.1');
-  }
-
-, "n_cycle.js": function (require, exports, module) {
-    exports.two = require('n_cycle.1');
-  }
-, "n_cycle.1.js": function (require, exports, module) {
-    exports.value = module.id;
-    exports.two = require('n_cycle.2');
-  }
-, "n_cycle.2.js": function (require, exports, module) {
-    exports.value = module.id;
-    exports.three = require('n_cycle.3');
-  }
-, "n_cycle.3.js": function (require, exports, module) {
-    exports.value = module.id;
-    exports.one = require('n_cycle.1');
-  }
+  it("should validate parameters", function () {
+    var r = requireForPaths('/dev/null', '/dev/null');
+    assert.throws(function () {r.define()}, "ArgumentError");
+    assert.throws(function () {r.define(null, null)}, "ArgumentError");
+  });
 });
 
-assertThrow(function () {r('one_cycle')}, 'CircularDependency');
-assertThrow(function () {r('two_cycle')}, 'CircularDependency');
-assertThrow(function () {r('n_cycle')}, 'CircularDependency');
+describe('require', function () {
+  var r = requireForPaths(modulesPath + '/root', modulesPath + '/library');
+  it("should resolve libraries", function () {
+    assert.equal('1.js', r('1.js').value);
+    assert.equal('/1.js', r('/1.js').value);
+  });
 
-r = requireForPaths();
-r.define({
-  "non_cycle.js": function (require, exports, module) {
-    exports.value = module.id;
-    require("non_cycle.1.js");
-  }
-, "non_cycle.1.js": function (require, exports, module) {
-    exports.value = module.id;
-    require("non_cycle.2.js", function (two) {exports.one = two});
-  }
-, "non_cycle.2.js": function (require, exports, module) {
-    exports.value = module.id;
-    require("non_cycle.1.js", function (one) {exports.one = one});
-  }
+  it("should resolve suffixes", function () {
+    assert.equal('/1.js', r('/1').value);
+    assert.equal(r('/1.js'), r('/1'));
+  });
+
+  it("should handle spaces", function () {
+    var r = requireForPaths(modulesPath + '/root', modulesPath + '/library');
+    assert.equal('/spa ce s.js', r('/spa ce s.js').value);
+  });
+
+  it("should handle questionable \"extra\" relative paths", function () {
+    var r = requireForPaths(modulesPath + '/root', modulesPath + '/library');
+    assert.equal('/../root/1.js', r('/../root/1').value);
+    assert.equal('/../library/1.js', r('../library/1').value);
+  });
+
+  it("should handle relative peths in library modules", function () {
+    var r = requireForPaths('/dev/null', '/dev/null');
+    r.define("main.js", function (require, exports, module) {
+      exports.sibling = require('./sibling');
+    });
+    r.define("sibling.js", function (require, exports, module) {
+    });
+    assert.equal(r('main.js').sibling, r('sibling.js'));
+  });
+
+  it("should resolve indexes correctly", function () {
+    var r = requireForPaths(modulesPath + '/index');
+    assert.equal('/index.js', r('/').value);
+    assert.equal('/index.js', r('/index').value);
+    assert.equal('/index/index.js', r('/index/').value);
+    assert.equal('/index/index.js', r('/index/index').value);
+    assert.equal('/index/index.js', r('/index/index.js').value);
+    assert.equal('/index/index/index.js', r('/index/index/').value);
+    assert.equal('/index/index/index.js', r('/index/index/index.js').value);
+  });
+
+  it("should normalize paths", function () {
+    var r = requireForPaths(modulesPath + '/index');
+    assert.equal('/index.js', r('./index').value);
+    assert.equal('/index.js', r('/./index').value);
+    assert.equal('/index/index.js', r('/index/index/../').value);
+    assert.equal('/index/index.js', r('/index/index/../../index/').value);
+  });
+
+  it("should validate parameters", function () {
+    var r = requireForPaths('/dev/null', '/dev/null');
+    assert.throws(function () {r(null)}, 'toString');
+    assert.throws(function () {r('1', '1')}, 'ArgumentError');
+    assert.throws(function () {r('1', '1', '1')}, 'ArgumentError');
+  });
+
+  it("should detect cycles", function () {
+    r = requireForPaths('/dev/null', '/dev/null');
+    r.define({
+      "one_cycle.js": function (require, exports, module) {
+        exports.value = module.id;
+        exports.one = require('one_cycle');
+      }
+
+    , "two_cycle.js": function (require, exports, module) {
+        exports.two = require('two_cycle.1');
+      }
+    , "two_cycle.1.js": function (require, exports, module) {
+        exports.value = module.id;
+        exports.two = require('two_cycle.2');
+      }
+    , "two_cycle.2.js": function (require, exports, module) {
+        exports.value = module.id;
+        exports.one = require('two_cycle.1');
+      }
+
+    , "n_cycle.js": function (require, exports, module) {
+        exports.two = require('n_cycle.1');
+      }
+    , "n_cycle.1.js": function (require, exports, module) {
+        exports.value = module.id;
+        exports.two = require('n_cycle.2');
+      }
+    , "n_cycle.2.js": function (require, exports, module) {
+        exports.value = module.id;
+        exports.three = require('n_cycle.3');
+      }
+    , "n_cycle.3.js": function (require, exports, module) {
+        exports.value = module.id;
+        exports.one = require('n_cycle.1');
+      }
+    });
+
+    assert.throws(function () {r('one_cycle')}, 'CircularDependency');
+    assert.throws(function () {r('two_cycle')}, 'CircularDependency');
+    assert.throws(function () {r('n_cycle')}, 'CircularDependency');
+  });
+
+  it("should avoid avoidable cycles", function () {
+    r = requireForPaths();
+    r.define({
+      "non_cycle.js": function (require, exports, module) {
+        exports.value = module.id;
+        require("non_cycle.1.js");
+      }
+    , "non_cycle.1.js": function (require, exports, module) {
+        exports.value = module.id;
+        require("non_cycle.2.js", function (two) {exports.one = two});
+      }
+    , "non_cycle.2.js": function (require, exports, module) {
+        exports.value = module.id;
+        require("non_cycle.1.js", function (one) {exports.one = one});
+      }
+    });
+
+    assert.doesNotThrow(function () {
+      r("non_cycle.1.js");
+    }, 'CircularDependency');
+  });
+
 });
-var non1 = r("non_cycle.1.js");
-
-console.log("All done")


### PR DESCRIPTION
The etherpad-require-kernel repository was forked at an older revision of the [upstream require-kernel repository](https://github.com/cweider/require-kernel) (upstream v1.0.5, not v1.0.6). This PR merges in the changes that were not included in the fork.

It is not clear to me why this repository was forked at an older revision; [the commit message](https://github.com/ether/etherpad-require-kernel/commit/0ee050acb6ecd3ff8e76f1e758ba30897643a02e) doesn't give any rationale. I'm assuming it was a mistake. @JohnMcLear: Do you remember the history?