### PR TITLE
Add alias support

### DIFF
--- a/kernel.js
+++ b/kernel.js
@@ -322,8 +322,6 @@
   };
 
   const fetchDefineJSONP = (path) => {
-    const head =
-        document.head || document.getElementsByTagName('head')[0] || document.documentElement;
     const script = document.createElement('script');
     if (script.async !== undefined) {
       script.async = 'true';
@@ -339,7 +337,7 @@
       definitionWaiters[path].unshift(() => clearTimeout(timeoutId));
     }
 
-    head.insertBefore(script, head.firstChild);
+    document.head.insertBefore(script, document.head.firstChild);
   };
 
   /* Modules */

--- a/kernel.js
+++ b/kernel.js
@@ -179,10 +179,8 @@
         if (components[components.length - 1] === libraryLookupComponent) {
           components.pop();
         }
-        const searchPath = normalizePath(fullyQualifyPath(
-            `./${libraryLookupComponent}/${path}`, `${components.join('/')}/`
-        ));
-        paths.push(searchPath);
+        paths.push(normalizePath(
+            fullyQualifyPath(`./${libraryLookupComponent}/${path}`, `${components.join('/')}/`)));
         components.pop();
       }
       paths.push(path);
@@ -324,9 +322,8 @@
   };
 
   const fetchDefineJSONP = (path) => {
-    const head = document.head ||
-      document.getElementsByTagName('head')[0] ||
-      document.documentElement;
+    const head =
+        document.head || document.getElementsByTagName('head')[0] || document.documentElement;
     const script = document.createElement('script');
     if (script.async !== undefined) {
       script.async = 'true';
@@ -368,10 +365,8 @@
         currentRequests--;
         checkScheduledfetchDefines();
       });
-      if (globalKeyPath &&
-        typeof document !== 'undefined' &&
-          document.readyState &&
-            /^loaded|complete$/.test(document.readyState)) {
+      if (globalKeyPath && typeof document !== 'undefined' && document.readyState &&
+          /^loaded|complete$/.test(document.readyState)) {
         fetchDefineJSONP(fetchRequest);
       } else {
         fetchDefineXHR(fetchRequest, true);

--- a/kernel.js
+++ b/kernel.js
@@ -132,12 +132,10 @@
 
   const fullyQualifyPath = (path, basePath) => {
     let fullyQualifiedPath = path;
-    if (path.charAt(0) === '.' &&
-        (path.charAt(1) === '/' ||
-         (path.charAt(1) === '.' && path.charAt(2) === '/'))) {
+    if (path.startsWith('./') || path.startsWith('../')) {
       if (!basePath) {
         basePath = '';
-      } else if (basePath.charAt(basePath.length - 1) !== '/') {
+      } else if (!basePath.endsWith('/')) {
         basePath += '/';
       }
       fullyQualifiedPath = basePath + path;
@@ -149,11 +147,11 @@
     if (!URI) {
       throw new ArgumentError('Invalid root URI.');
     }
-    rootURI = URI.charAt(URI.length - 1) === '/' ? URI.slice(0, -1) : URI;
+    rootURI = URI.endsWith('/') ? URI.slice(0, -1) : URI;
   };
 
   const setLibraryURI = (URI) => {
-    libraryURI = URI.charAt(URI.length - 1) === '/' ? URI : `${URI}/`;
+    libraryURI = URI.endsWith('/') ? URI : `${URI}/`;
   };
 
   const setLibraryLookupComponent = (component) => {
@@ -173,7 +171,7 @@
     path = normalizePath(path);
 
     // Should look for nearby libarary modules.
-    if (path.charAt(0) !== '/' && libraryLookupComponent) {
+    if (!path.startsWith('/') && libraryLookupComponent) {
       const paths = [];
       const components = basePath.split('/');
 
@@ -201,7 +199,7 @@
     }
     path = components.join('/');
 
-    if (path.charAt(0) === '/') {
+    if (path.startsWith('/')) {
       if (!rootURI) {
         throw new Error(
             `Attempt to retrieve the root module "${path}" but no root URI is defined.`);

--- a/kernel.js
+++ b/kernel.js
@@ -489,9 +489,10 @@
   const moduleIsDefined = (path) => hasOwnProperty(definitions, path);
 
   const defineModule = (path, module) => {
-    if (typeof path !== 'string' ||
-        !((typeof module === 'function') || module === null)) { // eslint-disable-line eqeqeq
-      throw new ArgumentError('Definition must be a (string, function) pair.');
+    if (typeof path !== 'string') throw new ArgumentError('path must be a string');
+    path = normalizePath(path);
+    if (module !== null && typeof module !== 'function') { // eslint-disable-line eqeqeq
+      throw new ArgumentError('definition must be a function or null');
     }
 
     if (moduleIsDefined(path)) {


### PR DESCRIPTION
Multiple commits:
* Replace `charAt` checks with `startsWith`/`endsWith`
* Reformat to improve readability
* Assume `document.head` always exists
* Normalize the path when defining a module
* Add support for aliases

Draft for now because I still need to add tests.